### PR TITLE
Feat[fees]: use bitcoin-cli or nigiri based on network for fee estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,5 +351,5 @@ curl http://localhost:3030/api/wallet/onchain-balance
 
 ### Limitations with On-chain tx:
 - ~~**Transaction History**: Currently only displays Ark-related transactions. On-chain transaction integration is pending.~~
-- **Fee Estimation**: Uses hardcoded minimum fees (160 sats for regtest). Dynamic fee estimation will be implemented.
+- ~~**Fee Estimation**: Uses hardcoded minimum fees (160 sats for regtest). Dynamic fee estimation will be implemented.~~
 - **Coin Selection**: Uses largest first algorithm.


### PR DESCRIPTION
Detects whether the node is running on regtest or mainnet and selects the appropriate command-line tool (`nigiri` for regtest, `bitcoin-cli` for mainnet) to fetch smart fee estimates via estimatesmartfee RPC.